### PR TITLE
Support UPN changes.

### DIFF
--- a/DotNetNuke.Authentication.Azure/Components/AzureClient.cs
+++ b/DotNetNuke.Authentication.Azure/Components/AzureClient.cs
@@ -112,7 +112,7 @@ namespace DotNetNuke.Authentication.Azure.Components
                 AzureLastName = claims.FirstOrDefault(x => x.Type == JwtRegisteredClaimNames.FamilyName)?.Value,
                 AzureDisplayName = claims.FirstOrDefault(x => x.Type == "name").Value,
                 Email = claims.FirstOrDefault(x => x.Type == JwtRegisteredClaimNames.UniqueName).Value,
-                Id = claims.FirstOrDefault(x => x.Type == JwtRegisteredClaimNames.UniqueName).Value
+                Id = claims.FirstOrDefault(x => x.Type == "oid").Value
             };
             return user as TUserData;
         }


### PR DESCRIPTION
**[Breaking Change]**

Right now when a user's UPN is changed in AAD, DNN throws a "User already exist" error because it attempts to register the user as the new user with their new UPN. This is problematic.


Using the AAD `ObjectId` claim as the `UserId` resolves this issue. `ObjectId` is guaranteed never to change in AAD.

"Contains a unique identifier of an object in Azure AD. This value is immutable and cannot be reassigned or reused. Use the object ID to identify an object in queries to Azure AD. " - https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-token-and-claims

This is a breaking change whereas users who have already registered will now have to re-register with their new Id, but same credentials. Their old account will have to be removed before. Alternatively, you may be able to get their ObjectId from AAD and make it match the UserId in the DNN Database and resolve the issue that way.