### PR TITLE
Get AutoMatchExistingUsers' value from settings

### DIFF
--- a/DotNetNuke.Authentication.Azure/Components/AzureClient.cs
+++ b/DotNetNuke.Authentication.Azure/Components/AzureClient.cs
@@ -228,7 +228,10 @@ namespace DotNetNuke.Authentication.Azure.Components
         {
             get
             {
-                return _autoMatchExistingUsers;
+                // Will always return true if _autoMatchExistingUsers is true
+                // Otherwise, it will return the value specified in the settings
+                // This code would have to be changed if we wanted it to always return false whenever _autoMatchExistingUsers is false
+                return _autoMatchExistingUsers || Settings.AutoMatchExistingUsers;
             }
         }
 


### PR DESCRIPTION
Change that had not been ported from B2C, necessary for AutoMatchExistingUsers to work properly.