### PR TITLE
Build Extensibility to prevent it from becoming a missing file

### DIFF
--- a/.build/ModulePackage.targets
+++ b/.build/ModulePackage.targets
@@ -58,6 +58,7 @@
     <Copy SourceFiles="$(MSBuildDnnBinPath)\Microsoft.IdentityModel.Tokens.dll" DestinationFolder="$(MSBuildProjectDirectory)\Package\bin"/>
     <Copy SourceFiles="$(MSBuildDnnBinPath)\Microsoft.IdentityModel.Logging.dll" DestinationFolder="$(MSBuildProjectDirectory)\Package\bin"/>
     <Copy SourceFiles="$(MSBuildDnnBinPath)\Microsoft.IdentityModel.JsonWebTokens.dll" DestinationFolder="$(MSBuildProjectDirectory)\Package\bin"/>
+    <Copy SourceFiles="$(MSBuildDnnBinPath)\DotNetNuke.Authentication.Azure.Extensibility.dll" DestinationFolder="$(MSBuildProjectDirectory)\Package\bin"/>
 
 	  <Copy SourceFiles="$(MSBuildDnnBinPath)\Microsoft.Graph.dll" DestinationFolder="$(MSBuildProjectDirectory)\Package\bin"/>
 	  <Copy SourceFiles="$(MSBuildDnnBinPath)\Microsoft.Graph.Core.dll" DestinationFolder="$(MSBuildProjectDirectory)\Package\bin"/>

--- a/DotNetNuke.Authentication.Azure/AzureADProvider.dnn
+++ b/DotNetNuke.Authentication.Azure/AzureADProvider.dnn
@@ -35,6 +35,10 @@
               <path>bin</path>
               <name>DotNetNuke.Authentication.Azure.dll</name>
             </assembly>
+	    <assembly>
+              <path>bin</path>
+              <name>DotNetNuke.Authentication.Azure.Extensibility.dll</name>
+            </assembly>
             <assembly>
               <path>bin</path>
               <name>System.IdentityModel.Tokens.Jwt.dll</name>


### PR DESCRIPTION
In the v4.2.0 release the Extensibility implementation did not build, thus making all its related code inaccesible. This pull request adds the necessary changes for the Extensibility implementation to build properly.