### PR TITLE
fix: change inconsistent prefix name

### DIFF
--- a/DotNetNuke.Authentication.Azure/Components/AzureUserData.cs
+++ b/DotNetNuke.Authentication.Azure/Components/AzureUserData.cs
@@ -73,7 +73,7 @@ namespace DotNetNuke.Authentication.Azure.Components
                 FirstName = this.FirstName,
                 LastName = this.LastName,
                 Email = this.Email,
-                Username = usernamePrefixEnabled ? $"AzureAD-{this.Id}" : this.Id
+                Username = usernamePrefixEnabled ? $"Azure-{this.Id}" : this.Id
             };
         }
 


### PR DESCRIPTION
Prefixes are normally named 'Azure-', but this part of the code was using 'AzureAD-' instead.