### PR TITLE
FIX: Properly exclude packages and node_modules

### DIFF
--- a/.build/ModulePackage.targets
+++ b/.build/ModulePackage.targets
@@ -19,7 +19,7 @@
 
     <!--in VS 2012 we exclude the packages folder -->
     <ItemGroup>
-      <InstallInclude Include="**\*.txt;**\*.ascx;**\*.css"  Exclude="**\obj\**;**\_ReSharper*\**;packages\**;" />
+      <InstallInclude Include="**\*.txt;**\*.ascx;**\*.css"  Exclude="**\obj\**;**\_ReSharper*\**;**\packages\**;**\node_modules\**;" />
       <InstallInclude Include="**\images\*.png" />
       <InstallInclude Include="**\App_LocalResources\*.resx" />
     </ItemGroup>


### PR DESCRIPTION
Fixes issue #92.

The 'packages' folder is still created, but it only contains DotNetNuke-related directories. Without the Exclude it would contain more.